### PR TITLE
cli/verbs.go: Write a Job Report

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,6 @@
+package env
+
+const (
+	EnvLogFile     = "FIRMWARECI_LOGFILE"
+	DefaultLogFile = "/logs/job.result"
+)


### PR DESCRIPTION
  This will create a json file under /logs/job.result, which firmwareci
  can pull out of the docker container and parse.

Signed-off-by: Jo <johannes.bartunek@9elements.com>