### PR TITLE
pkg/env/env.go: Rename "FirmwareciSSHPublicKey" -> "FirmwareciSSHKey"

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -146,12 +146,12 @@ func downloadSFTP(file *os.File, URL *url.URL) error {
 		return errors.New("No User Account or password provided")
 	}
 
-	keyFile, err := os.Open(env.FirmwareciSSHPublicKey)
+	keyFile, err := os.Open(env.FirmwareciSSHKey)
 	if err != nil {
 		return err
 	}
 
-	privateKey, err := io.ReadAll(keyFile)
+	sshKey, err := io.ReadAll(keyFile)
 	if err != nil {
 		return err
 	}
@@ -159,9 +159,9 @@ func downloadSFTP(file *os.File, URL *url.URL) error {
 	var Signer ssh.Signer
 
 	if sshPW, set := os.LookupEnv(env.EnvSSHPrivatePW); set == false || sshPW != "" {
-		Signer, err = ssh.ParsePrivateKeyWithPassphrase(privateKey, []byte(sshPW))
+		Signer, err = ssh.ParsePrivateKeyWithPassphrase(sshKey, []byte(sshPW))
 	} else {
-		Signer, err = ssh.ParsePrivateKey(privateKey)
+		Signer, err = ssh.ParsePrivateKey(sshKey)
 	}
 
 	if err != nil {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,15 +1,15 @@
 package env
 
 const (
-	EnvLogFile             = "FIRMWARECI_LOGFILE"
-	DefaultLogFile         = "/logs/job.result"
-	DefaultBinaryDir       = "/root/assets/testbin/"
-	EnvBinUrl              = "FIRMWARECI_BINURL"
-	EnvBinDir              = "FIRMWARECI_BINDIR"
-	EnvSSHHostPublic       = "FIRMWARECI_HOSTPUB"
-	EnvSSHPrivatePW        = "FIRMWARECI_SSHPRIVATEPW"
-	EnvS3Access            = "FIRMWARECI_S3_ACCESS"
-	EnvS3Secret            = "FIRMWARECI_S3_SECRET"
-	EnvS3Region            = "FIRMWARECI_S3_REGION"
-	FirmwareciSSHPublicKey = "/root/.ssh/firmwareci.pub"
+	EnvLogFile       = "FIRMWARECI_LOGFILE"
+	DefaultLogFile   = "/logs/job.result"
+	DefaultBinaryDir = "/root/assets/testbin/"
+	EnvBinUrl        = "FIRMWARECI_BINURL"
+	EnvBinDir        = "FIRMWARECI_BINDIR"
+	EnvSSHHostPublic = "FIRMWARECI_HOSTPUB"
+	EnvSSHPrivatePW  = "FIRMWARECI_SSHPRIVATEPW"
+	EnvS3Access      = "FIRMWARECI_S3_ACCESS"
+	EnvS3Secret      = "FIRMWARECI_S3_SECRET"
+	EnvS3Region      = "FIRMWARECI_S3_REGION"
+	FirmwareciSSHKey = "/root/.ssh/firmwareci.pub"
 )

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -11,5 +11,5 @@ const (
 	EnvS3Access      = "FIRMWARECI_S3_ACCESS"
 	EnvS3Secret      = "FIRMWARECI_S3_SECRET"
 	EnvS3Region      = "FIRMWARECI_S3_REGION"
-	FirmwareciSSHKey = "/root/.ssh/firmwareci.pub"
+	FirmwareciSSHKey = "/root/.ssh/firmwareci"
 )


### PR DESCRIPTION
  The key is a private key not a public key, shoutout to @llogen
  for pointing that out.

Signed-off-by: Jo <johannes.bartunek@9elements.com>