### PR TITLE
descriptors/coreboot-up2-linuxboot

### DIFF
--- a/descriptors/coreboot-up2-linuxboot.yaml
+++ b/descriptors/coreboot-up2-linuxboot.yaml
@@ -18,21 +18,21 @@ TestDescriptors:
                 -   name: dutctl
                     label: power off1
                     parameters:
-                        serverAddr: ["penguin.lab.9e.network"]
+                        serverAddr: ["penguin"]
                         command: ["power"]
                         args: ["off"]
 
                 -   name: dutctl
                     label: flash 
                     parameters:
-                        serverAddr: ["penguin.lab.9e.network"]
+                        serverAddr: ["penguin"]
                         command: ["flash"]
                         args: ["write", "[[ .BinaryPath ]]"]
 
                 -   name: dutctl
                     label: power on
                     parameters:
-                        serverAddr: ["penguin.lab.9e.network"]
+                        serverAddr: ["penguin"]
                         command: ["power"]
                         args: ["on"]
                         expect: ["Welcome to u-root!"]
@@ -41,7 +41,7 @@ TestDescriptors:
                 -   name: dutctl
                     label: power off2
                     parameters:
-                        serverAddr: ["penguin.lab.9e.network"]
+                        serverAddr: ["penguin"]
                         command: ["power"]
                         args: ["off"]
 


### PR DESCRIPTION
Change on the raspberry pi hostname regarding the osfc demo setup.

Signed-off-by: llogen <christoph.lange@9elements.com>