### PR TITLE
descriptors/coreboot-up2-linuxboot.yaml: Edit timeout.

### DIFF
--- a/descriptors/coreboot-up2-linuxboot.yaml
+++ b/descriptors/coreboot-up2-linuxboot.yaml
@@ -36,7 +36,7 @@ TestDescriptors:
                         command: ["power"]
                         args: ["on"]
                         expect: ["Welcome to u-root!"]
-                        timeout: [1m]
+                        timeout: [2m]
 
                 -   name: dutctl
                     label: power off2


### PR DESCRIPTION
This commit adapts the timeout on the power on step to get sure it is enough time and the test passes.

Signed-off-by: llogen <christoph.lange@9elements.com>