### PR TITLE
descriptors: Fixing an issue with the teststep label.

### DIFF
--- a/descriptors/coreboot-up2-linuxboot.yaml
+++ b/descriptors/coreboot-up2-linuxboot.yaml
@@ -16,7 +16,7 @@ TestDescriptors:
             TestName: Simple Test
             Steps:
                 -   name: dutctl
-                    label: Prepare the flash step. Shutdown the device.
+                    label: Shutdown the device.
                     parameters:
                         serverAddr: ["penguin"]
                         command: ["power"]
@@ -30,7 +30,7 @@ TestDescriptors:
                         args: ["write", "[[ .BinaryPath ]]"]
 
                 -   name: dutctl
-                    label: Power on the device to check if it boots.
+                    label: Conduct the boot test.
                     parameters:
                         serverAddr: ["penguin"]
                         command: ["power"]

--- a/descriptors/coreboot-up2-linuxbootX100.yaml
+++ b/descriptors/coreboot-up2-linuxbootX100.yaml
@@ -15,7 +15,7 @@ TestDescriptors:
             TestName: Simple Test
             Steps:
                 -   name: dutctl
-                    label: Prepare the flash step. Shutdown the device.
+                    label: Shutdown the device.
                     parameters:
                         serverAddr: ["penguin"]
                         command: ["power"]
@@ -29,7 +29,7 @@ TestDescriptors:
                         args: ["write", "[[ .BinaryPath ]]"]
 
                 -   name: dutctl
-                    label: Powercycle the device to check if it boots 100 times.
+                    label: Conduct the powercycle test.
                     parameters:
                         serverAddr: ["penguin"]
                         command: ["power"]


### PR DESCRIPTION
The test step label has a maximum of 32 chars. So the label had to be adapted to fulfill this.

Signed-off-by: llogen <christoph.lange@9elements.com>